### PR TITLE
ISSUE-13: Fix dropping optional columns

### DIFF
--- a/src/test/scala/com/github/potix2/spark/google/spreadsheets/SpreadsheetSuite.scala
+++ b/src/test/scala/com/github/potix2/spark/google/spreadsheets/SpreadsheetSuite.scala
@@ -134,7 +134,9 @@ class SpreadsheetSuite extends FlatSpec with BeforeAndAfter {
     val personsDF = sqlContext.createDataFrame(personsRDD, personsSchema)
   }
 
-  "A DataFrame" should "be saved as a sheet" in new PersonDataFrame {
+  behavior of "A DataFrame"
+
+  it should "be saved as a sheet" in new PersonDataFrame {
     import com.github.potix2.spark.google.spreadsheets._
     withEmptyWorksheet { workSheetName =>
       personsDF.write
@@ -153,6 +155,17 @@ class SpreadsheetSuite extends FlatSpec with BeforeAndAfter {
       assert(result(0).getString(1) == "Kathleen")
       assert(result(0).getString(2) == "Cole")
     }
+  }
+
+  it should "infer it's schema from headers" in {
+    val results = sqlContext.read
+      .option("serviceAccountId", serviceAccountId)
+      .option("credentialPath", testCredentialPath)
+      .spreadsheet(s"$TEST_SPREADSHEET_ID/case3")
+
+    assert(results.columns.size === 2)
+    assert(results.columns.contains("a"))
+    assert(results.columns.contains("b"))
   }
 
   "A sparse DataFrame" should "be saved as a sheet, preserving empty cells" in new SparsePersonDataFrame {


### PR DESCRIPTION
https://github.com/potix2/spark-google-spreadsheets/issues/13

InferSchema uses a first row of values to infer a DF schema.
It works correctly only if all values are filled for the first row.
It is better to use headlines to infer columns.